### PR TITLE
Re-added logout and back button in homescreen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -54,6 +54,30 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF4A4A4A)),
+          onPressed: () => Navigator.of(context).pushReplacement(
+            MaterialPageRoute(builder: (_) =>  LoginScreen()),
+          ),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(
+              Icons.logout_rounded,
+              color: Color(0xFF6C63FF),
+              size: 26,
+            ),
+            onPressed: () {
+              Navigator.of(context).pushReplacement(
+                MaterialPageRoute(builder: (_) =>  LoginScreen()),
+              );
+            },
+          ),
+        ],
+      ),
       body: Stack(
         fit: StackFit.expand,
         children: [


### PR DESCRIPTION
Re-added logout and back button in homescreen.

Note: This feature was removed in recent commits hence adding back. Original commit for reference: https://github.com/Pujithakallu/supersetfirebase/commit/734ddde9bcf620c1be5036717af852284ef851ad

Refer screenshot:
<img width="1431" alt="Screenshot 2025-02-17 at 11 57 28 PM" src="https://github.com/user-attachments/assets/6405c859-2ba8-4355-8963-e3ee318518b7" />
